### PR TITLE
Added Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+CXX=g++
+#add -m32 if trying to build 32 
+CFLAGS=-std=c++1y -O3 -s -fopenmp
+
+nttg: nttg-avx2 nttg-sse2
+	$(CXX) $(CFLAGS) -o nttg      main.cpp
+
+nttg-avx2: 
+	$(CXX) $(CFLAGS) -o nttg-avx2 main.cpp -mavx2 -DSIMD=AVX2 
+
+nttg-sse2:
+	$(CXX) $(CFLAGS) -o nttg-sse2 main.cpp -msse2 -DSIMD=SSE2
+
+clean:
+	rm nttg nttg-avx2 nttg-sse2

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 CXX=g++
-#add -m32 if trying to build 32 
+#add -m32 if trying to build 32 bit binaries on 64 bit machines, will
+#also need gcc-multilib installed
 CFLAGS=-std=c++1y -O3 -s -fopenmp
 
-nttg: nttg-avx2 nttg-sse2
+nttg: nttg-avx2 nttg-sse2 rsg-avx2 rsg-sse2 rsg 
 	$(CXX) $(CFLAGS) -o nttg      main.cpp
 
 nttg-avx2: 
@@ -11,5 +12,14 @@ nttg-avx2:
 nttg-sse2:
 	$(CXX) $(CFLAGS) -o nttg-sse2 main.cpp -msse2 -DSIMD=SSE2
 
+rsg: 
+	$(CXX) $(CFLAGS) -o rsg      RS.cpp
+
+rsg-avx2: 
+	$(CXX) $(CFLAGS) -o rsg-avx2 RS.cpp -mavx2 -DSIMD=AVX2 
+
+rsg-sse2:
+	$(CXX) $(CFLAGS) -o rsg-sse2 RS.cpp -msse2 -DSIMD=SSE2
+
 clean:
-	rm nttg nttg-avx2 nttg-sse2
+	rm -f nttg nttg-avx2 nttg-sse2 rsg rsg-avx2 rsg-sse2


### PR DESCRIPTION
Added makefile.  I skipped the "-m32" since it requires packages I don't have (gcc-multilib and 30 other packages I don't have or want).  Should build 32 binaries on 32 bit systems and 64 bit binaries on 64 bit systems.  Comments in makefile mention adding -m32 if needed.

I avoided -static since it results in a rather noisy build with 3 of these:
g++ -std=c++1y -O3 -s -fopenmp -static -o nttg-avx2 main.cpp -mavx2 -DSIMD=AVX2 
/usr/lib/gcc/x86_64-linux-gnu/5/libgomp.a(target.o): In function `gomp_target_init':
(.text+0xba): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking

Without -static:
bill@left:~/git/FastECC$ make clean && make
rm -f nttg nttg-avx2 nttg-sse2
g++ -std=c++1y -O3 -s -fopenmp -o nttg-avx2 main.cpp -mavx2 -DSIMD=AVX2 
g++ -std=c++1y -O3 -s -fopenmp -o nttg-sse2 main.cpp -msse2 -DSIMD=SSE2
g++ -std=c++1y -O3 -s -fopenmp -o nttg      main.cpp

Change to taste.

